### PR TITLE
Fix https://github.com/jkramer/p6-Term-ReadKey/issues/3

### DIFF
--- a/lib/Term/ReadKey.pm6
+++ b/lib/Term/ReadKey.pm6
@@ -13,7 +13,7 @@ module Term::ReadKey:ver<0.0.1> {
     $flags.unset_lflags('ECHO') unless $echo;
     $flags.setattr(:NOW);
 
-    my $result = $fn();
+    my $result = $fn() // '';
 
     $original-flags.setattr(:NOW);
 


### PR DESCRIPTION
Fix the exception:

Type check failed for return value; expected Str but got Any (Any)


Solution adapter from https://github.com/ryn1x/p6-Term-ReadKey/commit/a1a895f71918ab65e0b1d42431e3fefb010a6cdc
